### PR TITLE
Disable overlay for kube-router

### DIFF
--- a/debian/kube-router.service
+++ b/debian/kube-router.service
@@ -17,3 +17,4 @@ ExecStart=env NODE_NAME=ix-truenas KUBE_ROUTER_CNI_CONF_FILE=/etc/cni/net.d/10-k
         '--run-service-proxy=true' \
         '--bgp-graceful-restart=true' \
         '--kubeconfig=/etc/cni/net.d/kube-router.d/kubeconfig' \
+        '--enable-overlay=false' \


### PR DESCRIPTION
This commit adds changes to disable overlay for kube-router. Motivation for this change are 2 reasons. Overlay is used to help pod to pod networking across nodes in different subnets with ip in ip tunneling. However we only have 1 node, so this is not really required.

Moving on, kube-router introduced change to automatically set MTU of kube-bridge interface in https://github.com/cloudnativelabs/kube-router/pull/989. With this change kube-router gets the MTU of the host interface which is being consumed by kubernetes and then does a -20 on the MTU value ( to account for ip in ip tunneling ) and sets the kube-bridge MTU to that value. This ends up with kube-bridge mostly using 1480 if host interface was 1500 ( which is the usual case ). Issue happens that some servers send length of 1440 ( apart from the other ethernet/ip frames ) with fragmentation flag unset which results in the packet getting dropped as the packet size is larger then what the interface can handle. I am discussing this with a kube-router developer and would make an issue upstream as well once he finalizes the scope.

This change fixes our TLS issues where popular sites like github could not be accessed reliably and we did not require ip in ip tunneling because that's not our use case, so from that aspect it's fine to disable overlay. ( nice reference read for selecting minimum MTU - https://blog.cloudflare.com/ip-fragmentation-is-broken/ )