### PR TITLE
Do not remove policy based routing rule

### DIFF
--- a/pkg/controllers/routing/pbr.go
+++ b/pkg/controllers/routing/pbr.go
@@ -39,6 +39,8 @@ func (nrc *NetworkRoutingController) disablePolicyBasedRouting() error {
 		return fmt.Errorf("failed to update rt_tables file: %s", err)
 	}
 
+	/*
+	We comment this to still have policy based routing for TN scale cluster
 	out, err := exec.Command("ip", "rule", "list").Output()
 	if err != nil {
 		return fmt.Errorf("failed to verify if `ip rule` exists: %s",
@@ -51,6 +53,7 @@ func (nrc *NetworkRoutingController) disablePolicyBasedRouting() error {
 			return fmt.Errorf("failed to delete ip rule: %s", err.Error())
 		}
 	}
+	*/
 
 	return nil
 }


### PR DESCRIPTION
This commit adds changes to comment a portion of kube-router source where it disables policy based routing which it does with the aid of ip in ip tunneling, the idea is that kube-router should not remove the ip rule added by us to enable policy based routing.