### PR TITLE
Change log level when replacing route

### DIFF
--- a/cmd/kube-router/kube-router.go
+++ b/cmd/kube-router/kube-router.go
@@ -37,7 +37,11 @@ func Main() error {
 	if err != nil {
 		return fmt.Errorf("failed to parse flags: %s", err)
 	}
-	err = flag.Set("logtostderr", "true")
+	err = flag.Set("logtostderr", "false")
+	if err != nil {
+		return fmt.Errorf("failed to set flag: %s", err)
+	}
+	err = flag.Set("alsoToStderr", "true")
 	if err != nil {
 		return fmt.Errorf("failed to set flag: %s", err)
 	}

--- a/pkg/controllers/proxy/network_services_controller.go
+++ b/pkg/controllers/proxy/network_services_controller.go
@@ -192,7 +192,7 @@ func (ln *linuxNetworking) ipAddrAdd(iface netlink.Link, ip string, addRoute boo
 		"table", "local", "proto", "kernel", "scope", "host", "src",
 		NodeIP.String(), "table", "local").CombinedOutput()
 	if err != nil {
-		klog.Errorf("Failed to replace route to service VIP %s configured on %s. Error: %v, Output: %s",
+		klog.Warningf("Failed to replace route to service VIP %s configured on %s. Error: %v, Output: %s",
 			ip, KubeDummyIf, err, out)
 	}
 	return nil


### PR DESCRIPTION
## Problem

When using a `LoadBalancer` service, `kube-router` does not account if the route already exists and still tries to perform the action whenever it syncs network controller which causes erroneous logs.

## Solution

Best would be to not try the replacement if it's already configured but it seems more involved with how kube-router manages it, so let's not spam logs.