### PR TITLE
Fix logging argument in kube-router

### DIFF
--- a/cmd/kube-router/kube-router.go
+++ b/cmd/kube-router/kube-router.go
@@ -37,11 +37,7 @@ func Main() error {
 	if err != nil {
 		return fmt.Errorf("failed to parse flags: %s", err)
 	}
-	err = flag.Set("logtostderr", "false")
-	if err != nil {
-		return fmt.Errorf("failed to set flag: %s", err)
-	}
-	err = flag.Set("alsoToStderr", "true")
+	err = flag.Set("logtostderr", "true")
 	if err != nil {
 		return fmt.Errorf("failed to set flag: %s", err)
 	}


### PR DESCRIPTION
Latest version of kube-router does not has 'alsotostderr' flag which results in kube-router not starting.