### PR TITLE
Specify environment variables in systemd unit file

### DIFF
--- a/debian/kube-router.service
+++ b/debian/kube-router.service
@@ -11,7 +11,9 @@ Type=exec
 TimeoutStartSec=0
 Restart=always
 RestartSec=5s
-ExecStart=env NODE_NAME=ix-truenas KUBE_ROUTER_CNI_CONF_FILE=/etc/cni/net.d/10-kuberouter.conflist /usr/local/bin/kube-router \
+Environment="NODE_NAME=ix-truenas"
+Environment="KUBE_ROUTER_CNI_CONF_FILE=/etc/cni/net.d/10-kuberouter.conflist"
+ExecStart=/usr/local/bin/kube-router \
         '--run-router=true' \
         '--run-firewall=true' \
         '--run-service-proxy=true' \


### PR DESCRIPTION
## Context

We want to move `kube-router` logs to separate file but `syslog` gets kube-router logs from `env` program as environment variables are specified with `env`.

## Solution

Specify environment variables in systemd unit file of `kube-router` instead of using `env` program.